### PR TITLE
fix: allow `nightly` cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ members = ["xtask"]
 all-features = true
 rustc-args = ["--cfg", "nightly"]
 rustdoc-args = ["--cfg", "nightly"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(nightly)'] }


### PR DESCRIPTION
The `unexpected_cfgs` doesn't know about the `nightly` cfg and warns about it. This PR fixes that warning.
