### PR TITLE
release twitch_types 0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ## [Unreleased] - ReleaseDate
 
-[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.5...Unreleased)
+[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.6...Unreleased)
+
+## [v0.4.6] - 2024-10-13
+
+[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.5...v0.4.6)
 
 - Added `SharedChatSessionId` and `WhisperId` (feature `chat`)
 - Added `EntitlementId`, `BenefitId`, `OrganizationId`, and `EntitlementCampaignId` (feature `entitlements`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_types"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "arbitrary",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch_types"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 repository = "https://github.com/twitch-rs/twitch_types"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twitch Types | Rust library for common types used in Twitch
 
-[![github]](https://github.com/twitch-rs/twitch_types)&ensp;[![crates-io]](https://crates.io/crates/twitch_types)&ensp;[![docs-rs-big]](https://docs.rs/twitch_types/0.4.5/twitch_types)
+[![github]](https://github.com/twitch-rs/twitch_types)&ensp;[![crates-io]](https://crates.io/crates/twitch_types)&ensp;[![docs-rs-big]](https://docs.rs/twitch_types/0.4.6/twitch_types)
 
 [github]: https://img.shields.io/badge/github-twitch--rs/twitch__types-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 [crates-io]: https://img.shields.io/crates/v/twitch_types.svg?style=for-the-badge&color=fc8d62&logo=rust


### PR DESCRIPTION
We only added new types and fixed lints - nothing breaking.