### PR TITLE
refactor: rename `ResubscriptionEmote` to `EmoteOccurrence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 [Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.7...Unreleased)
 
+- Changed `ResubscriptionEmote` to `EmoteOccurrence`
+- Deprecated `ResubscriptionEmote` (alias to `EmoteOccurrence`)
+
 ## [v0.4.7] - 2024-11-06
 
 [Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.6...v0.4.7)

--- a/src/emote.rs
+++ b/src/emote.rs
@@ -256,7 +256,7 @@ impl_extra!(EmoteSetId, EmoteSetIdRef);
 )]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[non_exhaustive]
-pub struct ResubscriptionEmote {
+pub struct EmoteOccurrence {
     /// The index of where the Emote starts in the text.
     pub begin: i64,
     /// The index of where the Emote ends in the text.
@@ -265,11 +265,15 @@ pub struct ResubscriptionEmote {
     pub id: EmoteId,
 }
 
-impl std::fmt::Display for ResubscriptionEmote {
+impl std::fmt::Display for EmoteOccurrence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}-{}", self.id, self.begin, self.end)
     }
 }
+
+/// An emote index as defined by eventsub, similar to IRC `emotes` twitch tag.
+#[deprecated(since = "0.4.8", note = "Use EmoteOccurrence instead")]
+pub type ResubscriptionEmote = EmoteOccurrence;
 
 /// Links to the same image of different sizes
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This is done for https://github.com/twitch-rs/twitch_api/issues/450. The [`emote`](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#emotes) type describes a general emote occurrence. I kept `ResubscriptionEmote` for backwards compatibility, but marked it as `deprecated`. I'm not exactly sure if that's fully semver compatible.