### PR TITLE
fix: remove removed `doc_auto_cfg` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![allow(clippy::extra_unused_lifetimes)]
 #![cfg_attr(nightly, feature(doc_cfg))]
-#![cfg_attr(nightly, feature(doc_auto_cfg))]
 //! Twitch types
 
 #[macro_use]


### PR DESCRIPTION
Removed in https://redirect.github.com/rust-lang/rust/pull/138907.