### PR TITLE
release twitch_types 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased] - ReleaseDate
 
+- Removed the nightly feature `doc_auto_cfg` (removed from Rust in https://redirect.github.com/rust-lang/rust/pull/138907)
+
 [Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.8...Unreleased)
 
 ## [v0.4.8] - 2024-11-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ## [Unreleased] - ReleaseDate
 
+[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.9...Unreleased)
+
+## [v0.4.9] - 2025-10-04
+
 - Removed the nightly feature `doc_auto_cfg` (removed from Rust in https://redirect.github.com/rust-lang/rust/pull/138907)
 
-[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.8...Unreleased)
+[Commits](https://github.com/twitch-rs/twitch_types/compare/v0.4.8...v0.4.9)
 
 ## [v0.4.8] - 2024-11-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_types"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "arbitrary",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitch_types"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 repository = "https://github.com/twitch-rs/twitch_types"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twitch Types | Rust library for common types used in Twitch
 
-[![github]](https://github.com/twitch-rs/twitch_types)&ensp;[![crates-io]](https://crates.io/crates/twitch_types)&ensp;[![docs-rs-big]](https://docs.rs/twitch_types/0.4.8/twitch_types)
+[![github]](https://github.com/twitch-rs/twitch_types)&ensp;[![crates-io]](https://crates.io/crates/twitch_types)&ensp;[![docs-rs-big]](https://docs.rs/twitch_types/0.4.9/twitch_types)
 
 [github]: https://img.shields.io/badge/github-twitch--rs/twitch__types-8da0cb?style=for-the-badge&labelColor=555555&logo=github
 [crates-io]: https://img.shields.io/crates/v/twitch_types.svg?style=for-the-badge&color=fc8d62&logo=rust


### PR DESCRIPTION
The only change is that `doc_auto_cfg` was removed. Other than that, the actions were updated.