### PR TITLE
Implement Extension types for EventSub Subscription

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -5,14 +5,14 @@ manual_braid! {
 }
 impl_extra!(ExtensionId, ExtensionIdRef);
 
-manual_braid!{
+manual_braid! {
     /// An Extension Client ID
     pub struct ExtensionClientId;
     pub struct ExtensionClientIdRef;
 }
 impl_extra!(ExtensionClientId, ExtensionClientIdRef);
 
-manual_braid!{
+manual_braid! {
     /// A Bits Transaction ID
     pub struct BitsTransactionId;
     pub struct BitsTransactionIdRef;


### PR DESCRIPTION
This PR implements the required additional types for the extension.bits_transaction.create subscription.

https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#extensionbits_transactioncreate